### PR TITLE
fix: prevent crash when junos_priocode is nil in ruby filter and wrong syntax in online-log-cm.yml

### DIFF
--- a/kubernetes/logstash/templates/offline-log-cm.yml
+++ b/kubernetes/logstash/templates/offline-log-cm.yml
@@ -95,7 +95,13 @@ data:
             convert => { "junos_priocode" => "integer" }
           }
           ruby {
-            code => 'event.set("junos_facilitycode", event.get("junos_priocode")/8)'
+            code => '
+              priocode = event.get("junos_priocode")
+              if priocode
+                event.set("junos_facilitycode", priocode / 8)
+                event.set("junos_severitycode", priocode % 8)
+              end
+            '
           }
           ruby {
             code => 'event.set("junos_severitycode", event.get("junos_priocode")%8)'

--- a/kubernetes/logstash/templates/online-log-cm.yml
+++ b/kubernetes/logstash/templates/online-log-cm.yml
@@ -165,13 +165,15 @@ data:
             mutate {
               add_tag => "alert_watermark"
             }
+          }
         }
       }
       # if ["message"] {
+      if "_grokparsefailure" not in [tags] {
       mutate {
           remove_field => [ "message" ]
         }
-      # }
+      }
     }
 
 


### PR DESCRIPTION
fix: prevent crash when junos_priocode is nil in ruby filter and wrong syntax in online-log-cm.yml