### PR TITLE
no-ci: Add initialization ConfigMap and update StatefulSet for custom…

### DIFF
--- a/kubernetes/mariadb-galera/templates/initialization-configmap.yaml
+++ b/kubernetes/mariadb-galera/templates/initialization-configmap.yaml
@@ -1,0 +1,30 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if and (or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScripts) (not .Values.initdbScriptsConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-init-scripts" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+{{- if and (.Files.Glob "files/docker-entrypoint-initdb.d/*.sql.gz") (not .Values.initdbScriptsConfigMap) }}
+binaryData:
+{{- $root := . }}
+{{- range $path, $bytes := .Files.Glob "files/docker-entrypoint-initdb.d/*.sql.gz" }}
+  {{ base $path }}: {{ $root.Files.Get $path | b64enc | quote }}
+{{- end }}
+{{- end }}
+data:
+{{- if and (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql}") (not .Values.initdbScriptsConfigMap) }}
+{{ (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql}").AsConfig | indent 2 }}
+{{- end }}
+{{- with .Values.initdbScripts }}
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{ end }}

--- a/kubernetes/mariadb-galera/templates/persistentvolume.yaml
+++ b/kubernetes/mariadb-galera/templates/persistentvolume.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled ( eq .Values.persistence.storageClass "mariadb" ) }}
+{{- if .Values.persistence.enabled }}
 # apiVersion: storage.k8s.io/v1
 # kind: StorageClass
 # metadata:
@@ -19,8 +19,8 @@ metadata:
     app.kubernetes.io/name: mariadb-galera
     statefulset.kubernetes.io/pod-name: "{{ $.Release.Name }}-mariadb-galera-{{ $index }}"
 spec:
-  # storageClassName: {{ $namespace }}-mariadb
-  storageClassName: mariadb
+  storageClassName: {{ default (printf "%s-mariadb" $namespace) $.Values.persistence.storageClass | quote }}
+  # storageClassName: mariadb
   capacity:
     storage: {{ $.Values.persistence.size | quote }}
   accessModes:

--- a/kubernetes/mariadb-galera/templates/persistentvolume.yaml
+++ b/kubernetes/mariadb-galera/templates/persistentvolume.yaml
@@ -9,7 +9,7 @@
 
 {{- $namespace := .Release.Namespace }}
 
-{{- range $index, $topping := until (int .Values.replicaCount) }}
+{{- range $index, $topping := until (int (index (index .Values.global "mariadb-galera") "replicaCount")) }}
 ---
 apiVersion: v1
 kind: PersistentVolume

--- a/kubernetes/mariadb-galera/templates/statefulset.yaml
+++ b/kubernetes/mariadb-galera/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- $namespace := .Release.Namespace }}
 apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
@@ -5,7 +6,7 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
-  replicas: {{ include "common.replicas" ( dict "replicaCount" ( index (index .Values.global "mariadb-galera") "replicaCount" ) "global" .Values.global ) }}
+  replicas: {{ include "common.replicas" ( dict "replicaCount" .Values.replicaCount "global" .Values.global ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   serviceName: {{ template "common.names.fullname" . }}-headless
@@ -273,8 +274,10 @@ spec:
               {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
               {{- end }}
+            {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
             - name: custom-init-scripts
               mountPath: /docker-entrypoint-initdb.d
+            {{- end }}
             {{- if or (.Files.Glob "files/my.cnf") .Values.mariadbConfiguration .Values.configurationConfigMap }}
             - name: mariadb-galera-config
               mountPath: /opt/bitnami/mariadb/conf/my.cnf
@@ -347,9 +350,11 @@ spec:
           configMap:
             name: {{ template "mariadb-galera.configurationCM" . }}
         {{- end }}
+        {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
         - name: custom-init-scripts
           configMap:
             name: {{ template "mariadb-galera.initdbScriptsCM" . }}
+        {{- end }}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
@@ -371,6 +376,7 @@ spec:
         {{- range .Values.persistence.accessModes }}
           - {{ . | quote }}
         {{- end }}
+        storageClassName: {{ default (printf "%s-mariadb" $namespace) $.Values.persistence.storageClass | quote }}
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}

--- a/kubernetes/mariadb-galera/templates/statefulset.yaml
+++ b/kubernetes/mariadb-galera/templates/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
-  replicas: {{ include "common.replicas" ( dict "replicaCount" .Values.replicaCount "global" .Values.global ) }}
+  replicas: {{ include "common.replicas" ( dict "replicaCount" (index (index .Values.global "mariadb-galera") "replicaCount") "global" .Values.global ) }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   serviceName: {{ template "common.names.fullname" . }}-headless
@@ -87,7 +87,7 @@ spec:
                 fi
                 {{- end }}
 
-                {{- if eq (1 | quote) (.Values.replicaCount | quote) }}
+                {{- if eq (1 | quote) ((index (index .Values.global "mariadb-galera") "replicaCount") | quote) }}
                 export MARIADB_GALERA_CLUSTER_BOOTSTRAP=no
                 export MARIADB_GALERA_FORCE_SAFETOBOOTSTRAP=no
                 {{- end }}

--- a/kubernetes/mariadb-galera/values.yaml
+++ b/kubernetes/mariadb-galera/values.yaml
@@ -4,7 +4,9 @@
 ##
 global:
   maxscale:
-    enabled: true
+    enabled: false
+  mariadb-galera:
+    replicaCount: 3
 #   imageRegistry: myRegistryName
 #   imagePullSecrets:
 #     - myRegistryKeySecretName

--- a/kubernetes/mariadb-galera/values.yaml
+++ b/kubernetes/mariadb-galera/values.yaml
@@ -3,8 +3,6 @@
 ## Current available global Docker image parameters: imageRegistry and imagePullSecrets
 ##
 global:
-  mariadb-galera:
-    replicaCount: 3
   maxscale:
     enabled: true
 #   imageRegistry: myRegistryName
@@ -520,7 +518,7 @@ persistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  storageClass: "mariadb"
+  storageClass: ""
   ## Persistent Volume Claim annotations
   ##
   annotations:


### PR DESCRIPTION
… init scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom initialization scripts for MariaDB Galera via a new initialization ConfigMap, including both file-based and inline scripts.

* **Improvements**
  * Made persistent volume storage class configurable and defaulted it to a namespace-scoped value if not specified.
  * Simplified configuration for replica count and storage class by removing unnecessary nesting and hardcoded defaults.
  * Initialization script volumes are now conditionally included only when relevant scripts are present.
  * Updated default persistence storage class to use cluster defaults when unspecified.
  * Changed default MaxScale enablement to false and reorganized its configuration hierarchy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->