### PR TITLE
fix: Update serviceAccountName in icingaweb health check CronJob temp…

### DIFF
--- a/kubernetes/icingaweb/templates/icingaweb_healthcheck_cronjob.yaml
+++ b/kubernetes/icingaweb/templates/icingaweb_healthcheck_cronjob.yaml
@@ -11,7 +11,7 @@ spec:
       ttlSecondsAfterFinished: 100
       template:
         spec:
-          serviceAccountName: icinga-sa  # Use the ServiceAccount for permissions
+          serviceAccountName: {{ .Release.Name }}-icinga-sa  # Use the ServiceAccount for permissions
           imagePullSecrets:
             - name: ghcr-pull-secret
           containers:


### PR DESCRIPTION
…late

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the service account used by the health check CronJob to dynamically match the Helm release name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->