### PR TITLE
fix: fix wrong seaweedfs sc name

### DIFF
--- a/kubernetes/shared-volume/templates/hostpath-pv.yaml
+++ b/kubernetes/shared-volume/templates/hostpath-pv.yaml
@@ -3,7 +3,7 @@
 {{- $enableHostPath := .Values.global.hostPathPV.enabled }}
 
 {{- range .Values.global.sharedPersistenceVolume }}
-{{- if and (ne .storageClass "seaweedfs") (hasKey . "folderName") $enableHostPath }}
+{{- if and (ne .storageClass "seaweedfs-storage") (hasKey . "folderName") $enableHostPath }}
 ---
 apiVersion: v1
 kind: PersistentVolume


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the logic for excluding certain storage classes from hostPath PersistentVolume creation, now excluding those with the storage class "seaweedfs-storage" instead of "seaweedfs".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->