### PR TITLE
fix: add RETENTION_SLA_DAYS configuration and enable notification feature by default

### DIFF
--- a/kubernetes/icinga2/templates/_icingadb-conf.tpl
+++ b/kubernetes/icinga2/templates/_icingadb-conf.tpl
@@ -16,6 +16,8 @@
   value: {{ .Values.global.database.icingadb.database | default "icingadb" | quote }}
 - name: RETENTION_HISTORY_DAYS
   value: {{ .Values.master.icingadb.env.RETENTION_HISTORY_DAYS | default "30" | quote }}
+- name: RETENTION_SLA_DAYS
+  value: {{ .Values.master.icingadb.env.RETENTION_SLA_DAYS | default "30" | quote }}
 - name: RETENTION_OPTION_ACKNOWLEDGEMENT
   value: {{ .Values.master.icingadb.env.RETENTION_OPTION_ACKNOWLEDGEMENT | default "30" | quote }} 
 - name: RETENTION_OPTION_COMMENT

--- a/kubernetes/icinga2/templates/statefulset-distribute-master.yaml
+++ b/kubernetes/icinga2/templates/statefulset-distribute-master.yaml
@@ -159,7 +159,6 @@ spec:
             - /bin/bash
             - -c
             - |
-              POD_INDEX=${POD_NAME: -1}
               cat > /etc/icingadb/icingadb.conf << EOF
               database:
                 host: $ICINGADB_DATABASE_HOST
@@ -176,7 +175,7 @@ spec:
                 # Number of days to RETAIN FULL HISTORICAL data. By default, historical data is retained forever.
                 history-days: $RETENTION_HISTORY_DAYS
                 # Number of days to retain historical data for SLA reporting. By default, it is retained forever.
-              #  sla-days:
+                sla-days: $RETENTION_SLA_DAYS
 
                 # Map of history category to number of days to retain its data in order to
                 # enable retention only for specific categories or to

--- a/kubernetes/icinga2/values.yaml
+++ b/kubernetes/icinga2/values.yaml
@@ -179,10 +179,10 @@ master:
     ido_cleanup_servicecheck: 7d
 
   notifications:
-    enable: false
+    enable: true
     mailhub_host: "postfix"
     mailhub_port: 25
-    relay_email: "ha.do@svtech.com.vn"
+    relay_email: "nmaa.alerts@gmail.com"
 
   # icingadb container
   icingadb:
@@ -195,6 +195,7 @@ master:
     env:
       TZ: Asia/Ho_Chi_Minh
       # RETENTION_HISTORY_DAYS: 30
+      # RETENTION_SLA_DAYS: 30
       # RETENTION_OPTION_ACKNOWLEDGEMENT: 30
       # RETENTION_OPTION_COMMENT: 30
       # RETENTION_OPTION_DOWNTIME: 30


### PR DESCRIPTION
fix: add RETENTION_SLA_DAYS configuration and enable notification feature by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new environment variable to configure SLA retention days for IcingaDB, with a default value of 30 days.

* **Configuration Changes**
  * Enabled notifications by default and updated the notification relay email address.
  * Exposed the SLA retention days setting for easier customization via configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->