### PR TITLE
fix: health check cronjob - ensure failed jobs are not retained

### DIFF
--- a/kubernetes/icingaweb/templates/icingaweb_healthcheck_cronjob.yaml
+++ b/kubernetes/icingaweb/templates/icingaweb_healthcheck_cronjob.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   schedule: "*/30 * * * *"  # Run every 30 minutes
+  failedJobsHistoryLimit: 0 # Don't keep failed jobs
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 100
@@ -42,7 +43,7 @@ spec:
                   echo "Icinga DB state is $ICINGA_DB_STATE (ne 0), restarting Icinga DB container."
                   kubectl get pod -n {{ .Release.Namespace }} | grep icinga2-master | awk '{print $1}' | while read -r POD ; do
                     kubectl -n {{ .Release.Namespace }} exec $POD -c icingadb -- /bin/bash -c "kill 1"
-                  done 
+                  done
                 fi
                 # Check if redis module is unhealthy
                 if [[ "$REDIS_STATE" -ne 0 ]]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Icinga Web healthcheck CronJob to not retain failed job history, reducing noise and resource usage from accumulated failures. Runtime behavior and scheduling remain unchanged.
* **Style**
  * Minor whitespace cleanup with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->