### PR TITLE
fix: Add timezone and fix template list of kafka brokers

### DIFF
--- a/kubernetes/akvorado/templates/akvorado-console-deployment.yaml
+++ b/kubernetes/akvorado/templates/akvorado-console-deployment.yaml
@@ -38,6 +38,8 @@ spec:
           env:
             - name: AKVORADO_CFG_CONSOLE_DATABASE_DSN
               value: /run/akvorado/console.sqlite
+            - name: TZ
+              value: {{ include "common.timezone" ( dict "timezone" .Values.timezone "global" .Values.global) }}
           image: {{ include "common.images.image" ( dict "imageRoot" .Values.console.image ) }}
           imagePullPolicy: {{ .Values.console.image.pullPolicy | quote }}
           name: console

--- a/kubernetes/akvorado/templates/akvorado-inlet-deployment.yaml
+++ b/kubernetes/akvorado/templates/akvorado-inlet-deployment.yaml
@@ -38,6 +38,8 @@ spec:
           env:
             - name: AKVORADO_CFG_INLET_METADATA_CACHEPERSISTFILE
               value: /run/akvorado/metadata.cache
+            - name: TZ
+              value: {{ include "common.timezone" ( dict "timezone" .Values.timezone "global" .Values.global) }}
           image: {{ include "common.images.image" ( dict "imageRoot" .Values.inlet.image ) }}
           imagePullPolicy: {{ .Values.inlet.image.pullPolicy | quote }}
           name: inlet

--- a/kubernetes/akvorado/templates/akvorado-orchestrator-configmap.yaml
+++ b/kubernetes/akvorado/templates/akvorado-orchestrator-configmap.yaml
@@ -11,7 +11,9 @@ data:
       topic: {{ .Values.global.kafka.topic }}
       version: 3.8.0
       brokers:
-        - {{ .Release.Name }}-kafka-external-bootstrap.{{ .Release.Namespace }}.svc.cluster.local:9094
+      {{- range $i, $e := until (int .Values.global.kafka.replicationFactor) }}
+        - {{ $.Release.Name }}-kafka-{{ $i }}.{{ $.Release.Name }}-kafka-brokers.{{ $.Release.Namespace }}.svc.cluster.local:9092
+      {{- end }}
       topic-configuration:
         num-partitions: {{ .Values.global.kafka.partition }}
         replication-factor: {{ .Values.global.kafka.replicationFactor }}
@@ -49,7 +51,7 @@ data:
       username: {{ .Values.clickhouse.username }}
       password: {{ .Values.clickhouse.password | quote }}
       {{- end }}
-      
+
       prometheus-endpoint: /metrics
       asns:
         64501: ACME Corporation

--- a/kubernetes/akvorado/templates/akvorado-orchestrator-deployment.yaml
+++ b/kubernetes/akvorado/templates/akvorado-orchestrator-deployment.yaml
@@ -41,17 +41,22 @@ spec:
               value:  {{ .Values.geoip.env.ipinfo_db | quote }}
             - name: UPDATE_FREQUENCY
               value:  {{ .Values.geoip.env.update_time | quote }}
+            {{- if (not (empty .Values.global.proxy)) }}
             - name: HTTP_PROXY
               value: {{ .Values.global.proxy | quote }}
             - name: HTTPS_PROXY
               value: {{ .Values.global.proxy | quote }}
+            {{- end }}
           volumeMounts:
             - mountPath: /data
               name: {{ .Values.geoip.sharedPersistenceVolume.volumeName }}
         - args:
             - orchestrator
             - /etc/akvorado/akvorado.yaml
-          image: {{ include "common.images.image" ( dict "imageRoot" .Values.orchestrator.image ) }} 
+          image: {{ include "common.images.image" ( dict "imageRoot" .Values.orchestrator.image ) }}
+          env:
+            - name: TZ
+              value: {{ include "common.timezone" ( dict "timezone" .Values.timezone "global" .Values.global) }}
           name: orchestrator
           volumeMounts:
             - mountPath: /etc/akvorado

--- a/kubernetes/akvorado/templates/akvorado-redis-deployment.yaml
+++ b/kubernetes/akvorado/templates/akvorado-redis-deployment.yaml
@@ -25,6 +25,8 @@ spec:
         - env:
             - name: ALLOW_EMPTY_PASSWORD
               value: "yes"
+            - name: TZ
+              value: {{ include "common.timezone" ( dict "timezone" .Values.timezone "global" .Values.global) }}
           image: {{ include "common.images.image" ( dict "imageRoot" .Values.redis.image ) }}
           imagePullPolicy: {{ .Values.redis.image.pullPolicy | quote }}
           livenessProbe:

--- a/kubernetes/akvorado/values.yaml
+++ b/kubernetes/akvorado/values.yaml
@@ -9,6 +9,7 @@ global:
     partition: 1
     replicationFactor: 1
 
+timezone: "Asia/Ho_Chi_Minh"
 init:
   image:
     registry: docker.io

--- a/kubernetes/clickhouse/templates/clickhouse.yaml
+++ b/kubernetes/clickhouse/templates/clickhouse.yaml
@@ -62,6 +62,9 @@ spec:
             - name: clickhouse
               image: {{ include "common.images.image" ( dict "imageRoot" .Values.clickhouse.image) }}
               imagePullPolicy: {{ .Values.clickhouse.image.pullPolicy }}
+              env:
+                - name: TZ
+                  value: {{ include "common.timezone" ( dict "timezone" .Values.timezone "global" .Values.global) }}
           {{- if .Values.global.akvorado.enabled }}
               volumeMounts:
                 - name: initdb-volume

--- a/kubernetes/clickhouse/templates/clickhouseKeeper.yaml
+++ b/kubernetes/clickhouse/templates/clickhouseKeeper.yaml
@@ -48,7 +48,10 @@ spec:
             - name: clickhouse-keeper
               imagePullPolicy: {{ .Values.clickhouseKeeper.image.pullPolicy }}
               image: {{ include "common.images.image" ( dict "imageRoot" .Values.clickhouseKeeper.image) }}
-              resources: {{ toYaml .Values.clickhouseKeeper.resources | nindent 16 }}    
+              resources: {{ toYaml .Values.clickhouseKeeper.resources | nindent 16 }}
+              env:
+                - name: TZ
+                  value: {{ include "common.timezone" ( dict "timezone" .Values.timezone "global" .Values.global) }}
           securityContext: {{ toYaml .Values.clickhouseKeeper.securityContext | nindent 12 }}
 
     volumeClaimTemplates:

--- a/kubernetes/clickhouse/values.yaml
+++ b/kubernetes/clickhouse/values.yaml
@@ -15,6 +15,8 @@ global:
   clickhouseKeeper:
     enabled: true
 
+timezone: "Asia/Ho_Chi_Minh"
+
 clickhouseKeeper:
   replicaCount: 3
   image:

--- a/kubernetes/kafka/templates/kafka.yaml
+++ b/kubernetes/kafka/templates/kafka.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   kafka:
     version: {{ .Values.kafka.version }}
-    replicas: {{ .Values.kafka.replicaCount }}
+    replicas: {{ include "common.replicas" ( dict "replicaCount" .Values.global.kafka.replicationFactor "global" .Values.global ) }}
     listeners:
       - name: external
         port: 9094

--- a/kubernetes/kafka/values.yaml
+++ b/kubernetes/kafka/values.yaml
@@ -2,11 +2,11 @@ global:
   kafka:
     enabled: true
     topic: ""
+    replicationFactor: 3
 
 podAntiAffinityPreset: soft
 kafka:
   version: 3.8.0
-  replicaCount: 3
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Configurable timezone (TZ) added across Console, Inlet, Orchestrator, Redis, and ClickHouse.
  * Introduced ClickHouse Keeper configuration (replicas, image, resources, storage).

* Bug Fixes
  * Proxy variables for GeoIP sidecar are only set when a proxy is configured, preventing unintended proxying.

* Chores
  * Added timezone setting to Helm values for Akvorado and ClickHouse.
  * Kafka replicas now driven by a global replication factor; values updated accordingly.
  * Orchestrator now uses a dynamic Kafka brokers list based on replication factor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->