### PR TITLE
fix: disable workflow token for releasing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -580,6 +580,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: ${{ env.COMMIT_FULL_ID }}
           path: charts
           token: ${{ secrets.PUSH_TOKEN }}
@@ -587,6 +588,7 @@ jobs:
       - name: Checkout stacked_charts 
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: '${{ github.repository_owner }}/stacked_charts'
           token: ${{ secrets.PUSH_TOKEN }}
           path: stacked_charts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Hardened release workflow by disabling credential persistence in all checkout steps, reducing token exposure during automation.
  * Improves security posture of the CI release job without altering build logic or deployment behavior.
  * No user-facing changes; application functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->