### PR TITLE
fix: remove annotation from Chart.yaml

### DIFF
--- a/kubernetes/mage-ai/Chart.yaml
+++ b/kubernetes/mage-ai/Chart.yaml
@@ -1,33 +1,33 @@
-annotations:
-  artifacthub.io/alternativeName: Mage
-  artifacthub.io/category: integration-delivery
-  artifacthub.io/images: |
-    - name: mageai
-      image: mageai/mageai:0.9.72
-      platforms:
-        - linux/amd64
-        - linux/arm64
-    - name: busybox
-      image: busybox
-      whitelisted: true
-  artifacthub.io/license: Apache-2.0
-  artifacthub.io/links: |
-    - name: Homepage
-      url: https://www.mage.ai/
-    - name: Source
-      url: https://github.com/mage-ai/helm-charts
-    - name: Documentation
-      url: https://mage-ai.github.io/helm-charts/
-  artifacthub.io/maintainers: |
-    - name: Mage
-      email: eng@mage.ai
-  artifacthub.io/screenshots: |
-    - title: Build Pipeline
-      url: https://www.mage.ai/images/pages/home/screenshots/v5/Build@2x.png
-    - title: Preview Pipeline
-      url: https://www.mage.ai/images/pages/home/screenshots/v5/Preview@2x.png
-    - title: Launch Pipeline
-      url: https://www.mage.ai/images/pages/home/screenshots/v5/Launch@2x.webp
+# annotations:
+#   artifacthub.io/alternativeName: Mage
+#   artifacthub.io/category: integration-delivery
+#   artifacthub.io/images: |
+#     - name: mageai
+#       image: mageai/mageai:0.9.72
+#       platforms:
+#         - linux/amd64
+#         - linux/arm64
+#     - name: busybox
+#       image: busybox
+#       whitelisted: true
+#   artifacthub.io/license: Apache-2.0
+#   artifacthub.io/links: |
+#     - name: Homepage
+#       url: https://www.mage.ai/
+#     - name: Source
+#       url: https://github.com/mage-ai/helm-charts
+#     - name: Documentation
+#       url: https://mage-ai.github.io/helm-charts/
+#   artifacthub.io/maintainers: |
+#     - name: Mage
+#       email: eng@mage.ai
+#   artifacthub.io/screenshots: |
+#     - title: Build Pipeline
+#       url: https://www.mage.ai/images/pages/home/screenshots/v5/Build@2x.png
+#     - title: Preview Pipeline
+#       url: https://www.mage.ai/images/pages/home/screenshots/v5/Preview@2x.png
+#     - title: Launch Pipeline
+#       url: https://www.mage.ai/images/pages/home/screenshots/v5/Launch@2x.webp
 
 apiVersion: v2
 
@@ -39,14 +39,14 @@ appVersion: "0.9.72"
 
 description: A Helm chart for Mage AI
 
-home: https://www.mage.ai
+# home: https://www.mage.ai
 
-icon: https://avatars.githubusercontent.com/u/69371472
+# icon: https://avatars.githubusercontent.com/u/69371472
 
-maintainers:
-  - name: mage-ai
-    url: https://www.mage.ai
-    email: eng@mage.ai
+# maintainers:
+#   - name: mage-ai
+#     url: https://www.mage.ai
+#     email: eng@mage.ai
 
 name: mage-ai
 dependencies:

--- a/kubernetes/mage-ai/templates/service.yaml
+++ b/kubernetes/mage-ai/templates/service.yaml
@@ -20,4 +20,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "mageai.selectorLabels" . | nindent 4 }}
+    {{- include "mageai.webServerSelectorLabels" . | nindent 4 }}

--- a/kubernetes/mage-ai/values.yaml
+++ b/kubernetes/mage-ai/values.yaml
@@ -184,7 +184,7 @@ postgresql-ha: # Since we are using alias 'postgresql-ha' for the dependency
     image:
       registry: ghcr.io
       repository: svtechnmaa/postgresql-repmgr
-      tag: 17.6.0-debian-12-r2
+      tag: 14.5.0-debian-11-r19
       digest: ""
       pullPolicy: IfNotPresent
       pullSecrets:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart metadata configuration by commenting out chart annotations and related metadata fields.
  * Downgrade the postgresql-ha.postgresql.image.tag from 17.6.0-debian-12-r2 to 14.5.0-debian-11-r19 due to a repmgr initialization bug in version 17.6.0-debian-12-r2 that causes a "database does not exist" error. We will consider upgrading to a newer version after further testing is completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->