### PR TITLE
feat(maxscale): support multiple concurrent routers

### DIFF
--- a/kubernetes/maxscale/templates/deployment.yaml
+++ b/kubernetes/maxscale/templates/deployment.yaml
@@ -91,8 +91,23 @@ spec:
               value: {{ .Values.maxscaleConfig.monitor_user }}
             - name: MONITOR_PASSWORD
               value: {{ .Values.maxscaleConfig.monitor_user_password }}
+            - name: MAXSCALE_ROUTERS
+              value: "{{- range $i, $r := .Values.routers }}{{- if $i }},{{ end }}{{ $r.id }}{{- end }}"
+            {{- range .Values.routers }}
+            - name: MXS_{{ .id }}_TYPE
+              value: {{ .type | quote }}
+            - name: MXS_{{ .id }}_PORT
+              value: {{ .port | quote }}
+            {{- if .options }}
+            - name: MXS_{{ .id }}_ROUTER_OPTIONS
+              value: {{ .options | quote }}
+            {{- end }}
+            {{- end }}
           ports:
-          - containerPort: {{ .Values.maxscaleConfig.port }}
+          {{- range .Values.routers }}
+            - name: {{ .id | replace "_" "-" | trunc 15 }}
+              containerPort: {{ .port }}
+          {{- end }}
       imagePullSecrets:
       - name: ghcr-pull-secret
       affinity:
@@ -114,9 +129,12 @@ spec:
   selector:
     app.kubernetes.io/component: maxscale
   ports:
-    - protocol: TCP
-      port: 3306
-      targetPort: {{ .Values.maxscaleConfig.port }}
+    {{- range .Values.routers }}
+    - name: {{ .id | replace "_" "-" | trunc 15 }}
+      protocol: TCP
+      port: {{ .servicePort }}
+      targetPort: {{ .port }}
+    {{- end }}
   {{- if .Values.global.externalIP }}
   externalIPs:
   - {{ .Values.global.externalIP }}

--- a/kubernetes/maxscale/templates/deployment.yaml
+++ b/kubernetes/maxscale/templates/deployment.yaml
@@ -105,7 +105,7 @@ spec:
             {{- end }}
           ports:
           {{- range .Values.routers }}
-            - name: {{ .id | replace "_" "-" | trunc 15 }}
+            - name: {{ .id | lower | replace "_" "-" | trunc 15 | trimSuffix "-" }}
               containerPort: {{ .port }}
           {{- end }}
       imagePullSecrets:
@@ -130,7 +130,7 @@ spec:
     app.kubernetes.io/component: maxscale
   ports:
     {{- range .Values.routers }}
-    - name: {{ .id | replace "_" "-" | trunc 15 }}
+    - name: {{ .id | lower | replace "_" "-" | trunc 15 | trimSuffix "-" }}
       protocol: TCP
       port: {{ .servicePort }}
       targetPort: {{ .port }}

--- a/kubernetes/maxscale/values.yaml
+++ b/kubernetes/maxscale/values.yaml
@@ -26,6 +26,14 @@ maxscaleConfig:
     - db03://10.98.3.13:3306
   monitor_user: maxscale_monitor
   monitor_user_password: maxscale@123
-  port: 4006
+
+# List of MaxScale router services to expose. Each entry becomes a router
+# inside the container (env MXS_<id>_TYPE / _PORT / _ROUTER_OPTIONS) and a
+# port on the mariadb Service. Default = single readwritesplit on 4006.
+routers:
+  - id: rwsplit
+    type: readwritesplit
+    port: 4006
+    servicePort: 3306
 
 replicaCount: 2


### PR DESCRIPTION
## Summary
- Replace single-router assumption in the maxscale chart with a list-driven `routers` value; one MaxScale can now expose N router services (readwritesplit + readconnroute + schemarouter) simultaneously.
- Each entry produces its own container env pair (`MXS_<id>_TYPE` / `_PORT` / optional `_ROUTER_OPTIONS`), containerPort, and Kubernetes Service port pair (`servicePort` -> listener port).
- Removes the now-dead `maxscaleConfig.port` field. Default `routers:` list keeps the previous behaviour: a single `readwritesplit` router on 4006 exposed as Service port 3306.

## Backing image
Consumes `svtechnmaa/svtech_maxscale:v1.0.9` (released from svtechnmaa/stacked_charts#103) which added the `MAXSCALE_ROUTERS` + `MXS_<id>_*` env fan-out in the entrypoint.

## Test plan
Lab-verified against an isolated `maxscale-test` namespace on the SVTech lab cluster (chart 1.5.0, image v1.0.9), pointed at the existing Galera backend (node-01/02/03):
- [x] `helm install` with default values -> 1 service `rwsplit` / listener 4006 / svc `rwsplit 3306->4006`, servers Master + 2 Slaves.
- [x] `helm upgrade` with `routers:` extended to add `readconn_master` (readconnroute, port 4008, servicePort 3307, options `master`) -> 2 services, 2 listeners (4006 + 4008), svc ports `3306->4006` + `3307->4008`, servers preserved.
- [x] Namespace cleanly torn down; no existing release touched.

## Known follow-up (not in this PR)
- `svtech_maxscale` schemarouter script still references MaxScale 24.02-removed params (`allow_duplicate_databases`, `ignore_databases`, `ignore_databases_regex` -> should be `ignore_tables` / `ignore_tables_regex`). Separate image PR against stacked_charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2YyfDxSrFPLiHSF4gtuM