### PR TITLE
feat: declarative routers with per-router servers + params

### DIFF
--- a/kubernetes/maxscale/README.md
+++ b/kubernetes/maxscale/README.md
@@ -1,0 +1,132 @@
+# maxscale
+
+Helm chart deploying a MariaDB MaxScale pod in front of a MariaDB/Galera
+backend (or an external MariaDB/Galera cluster), plus a `mariadb` ClusterIP
+Service exposing one port per configured router.
+
+## What this chart deploys
+
+- A single `Deployment` running the `svtechnmaa/svtech_maxscale` image,
+  with an init container that waits until the backend database(s) accept
+  connections before MaxScale itself starts.
+- A `mariadb` `Service` (ClusterIP, or with `externalIPs` set) with one
+  port per entry in `routers`, so each router is reachable as its own
+  MySQL-protocol endpoint.
+- Router/monitor configuration is driven entirely by environment
+  variables derived from `values.yaml` — there is no static
+  `maxscale.cnf` shipped with the chart. Monitors are **not** declared in
+  values at all; the image auto-derives them from probing the backends
+  (see [How monitors work](#how-monitors-work)).
+
+## Values reference
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `replicaCount` | int | `2` | MaxScale pod replica count. |
+| `image.registry` | string | `ghcr.io` | Registry for the MaxScale image. |
+| `image.repository` | string | `svtechnmaa/svtech_maxscale` | MaxScale image repository. |
+| `image.tag` | string | `v1.0.10` | MaxScale image tag. `v1.0.10`+ is required for the `routers[*].servers` / `routers[*].params` fields below — older tags ignore those env vars but keep working via the legacy path. |
+| `image.pullPolicy` | string | `IfNotPresent` | Image pull policy. |
+| `init.image.*` | object | `svtechnmaa/mysql:8.2.0` | Image used by the `wait-for-mariadb` init container. |
+| `service.externalIPs` | list | `[]` | Reserved for future use (see `global.externalIP` for the currently-wired external IP). |
+| `maxscaleConfig.server` | list | 3 internal `dbNN://host:port` entries | Backend server list, **used only** when `global.mariadb-galera.enabled` is `false` (external database mode). Ignored when the bundled `mariadb-galera` subchart is enabled. |
+| `maxscaleConfig.monitor_user` | string | `maxscale_monitor` | DB user MaxScale uses to monitor backend health. |
+| `maxscaleConfig.monitor_user_password` | string | `maxscale@123` | Password for `monitor_user`. Override in production. |
+| `routers` | list | one `rwsplit` entry (see below) | List of MaxScale router services to expose. Each entry becomes a router inside the container and a port on the `mariadb` Service. |
+| `routers[*].id` | string | — | Router identifier. Becomes the `MXS_<id>_*` env var prefix and the Service port name. |
+| `routers[*].type` | string | — | MaxScale router type: `readwritesplit`, `readconnroute`, or `schemarouter`. |
+| `routers[*].port` | int | — | Container port the router listens on. |
+| `routers[*].servicePort` | int | — | Port exposed on the `mariadb` Service for this router. |
+| `routers[*].servers` | list of string | *(unset)* | Optional. Scopes this router to a backend subset (`MXS_<id>_SERVERS`). Omit to attach every backend. Requires image `v1.0.10`+. |
+| `routers[*].params` | map | *(unset)* | Optional. Free-form router tuning parameters, rendered as `MXS_<id>_<KEY>` (key upper-cased) per entry. See the image README's [router parameter reference](https://github.com/svtechnmaa/stacked_charts/blob/master/images/svtech_maxscale/README.md#router-parameter-reference) for the full list per router type. Requires image `v1.0.10`+. |
+| `routers[*].options` | string | *(unset)* | Legacy free-text `MXS_<id>_ROUTER_OPTIONS` string. Still supported for backward compatibility; prefer `params.router_options` in new configs. |
+
+## Router configuration
+
+- **`readwritesplit`** — splits reads and writes across the backend
+  subset, sending writes to the current primary and load-balancing reads
+  across replicas/other nodes. Pick this for a standard OLTP application
+  connection that shouldn't have to know about the topology.
+- **`readconnroute`** — routes every connection to servers matching a
+  fixed role (`master`, `slave`, or a combination via
+  `params.router_options`), without read/write splitting. Pick this for a
+  dedicated write endpoint that follows failover, or a read-only
+  offload endpoint for reporting/analytics traffic.
+- **`schemarouter`** — routes by schema/database name rather than by
+  role, and is the only router type allowed to span two different
+  topologies in `servers` (e.g. one Galera cluster and one standalone
+  node). Pick this when different schemas live on different backend
+  topologies and the application connects through one endpoint.
+
+## Examples
+
+The same three recipes are also available as commented-out blocks
+directly in `values.yaml`, ready to copy-paste over the default `routers:`
+list.
+
+**1. rwsplit with causal reads** — use this when the application needs
+read-your-writes consistency against a Galera cluster (an immediate read
+after a write must see that write, even if it lands on a different node):
+
+```yaml
+routers:
+  - id: rwsplit
+    type: readwritesplit
+    port: 4006
+    servicePort: 3306
+    params:
+      causal_reads: universal
+```
+
+**2. readconnroute pinned to master** — use this when you want a single
+write endpoint that always resolves to the current primary, transparently
+following failover:
+
+```yaml
+routers:
+  - id: write
+    type: readconnroute
+    port: 4007
+    servicePort: 3307
+    params:
+      router_options: master
+```
+
+**3. Multi-router mix** — use this when OLTP traffic needs read/write
+splitting, reporting traffic should be offloaded to replicas, and a
+separate schema-routed endpoint needs to span two topologies:
+
+```yaml
+routers:
+  - id: rwsplit
+    type: readwritesplit
+    port: 4006
+    servicePort: 3306
+    servers: [g1, g2, g3]
+  - id: readoffload
+    type: readconnroute
+    port: 4008
+    servicePort: 3308
+    servers: [g1, g2, g3]
+    params:
+      router_options: slave
+  - id: schema
+    type: schemarouter
+    port: 4009
+    servicePort: 3309
+    servers: [g1, m1]
+```
+
+## How monitors work
+
+Chart values never declare monitors. When any `routers[*].servers` is
+set, the image probes the declared backends at boot, groups them into
+topologies (Galera cluster, replication chain, or standalone node), and
+creates exactly the monitors each router's server subset needs —
+reusing one monitor per topology across routers that share it. If no
+router sets `servers`, the pod falls back to the original legacy
+behaviour: one monitor covering every backend, shared by every router.
+See the image README's
+[How auto-monitoring works](https://github.com/svtechnmaa/stacked_charts/blob/master/images/svtech_maxscale/README.md#how-auto-monitoring-works)
+section for the full topology-detection and guard-rail details.
+

--- a/kubernetes/maxscale/templates/_helpers.tpl
+++ b/kubernetes/maxscale/templates/_helpers.tpl
@@ -23,3 +23,37 @@
 {{- $server := .server -}}
 {{- join "," $server }}
 {{- end -}}
+
+{{/*
+Sanitize a router id into a k8s IANA port name:
+- lowercase
+- underscores replaced with hyphens
+- max 15 characters
+- no trailing hyphen
+*/}}
+{{- define "maxscale.portName" -}}
+{{- . | lower | replace "_" "-" | trunc 15 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Validate .Values.routers:
+- router ids must be unique
+- sanitized port names (see maxscale.portName) must be unique
+Fails template rendering with a clear message when either check fails.
+Call once from each resource that ranges over .Values.routers.
+*/}}
+{{- define "maxscale.assertUniqueRouters" -}}
+{{- $ids := dict -}}
+{{- $ports := dict -}}
+{{- range .Values.routers -}}
+  {{- if hasKey $ids .id -}}
+    {{- fail (printf "maxscale: duplicate router id %q in .Values.routers" .id) -}}
+  {{- end -}}
+  {{- $_ := set $ids .id true -}}
+  {{- $portName := include "maxscale.portName" .id -}}
+  {{- if hasKey $ports $portName -}}
+    {{- fail (printf "maxscale: routers %q and %q sanitize to the same port name %q — rename one" (index $ports $portName) .id $portName) -}}
+  {{- end -}}
+  {{- $_ := set $ports $portName .id -}}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/maxscale/templates/_helpers.tpl
+++ b/kubernetes/maxscale/templates/_helpers.tpl
@@ -27,12 +27,19 @@
 {{/*
 Sanitize a router id into a k8s IANA port name:
 - lowercase
-- underscores replaced with hyphens
-- max 15 characters
-- no trailing hyphen
+- any char outside [a-z0-9-] replaced with a hyphen
+- truncated to 15 characters
+- leading and trailing hyphens trimmed (after truncation, so trunc can't
+  leave a dangling '-')
+Fails template rendering if the sanitized result is empty (e.g. an id
+made only of separators like "___").
 */}}
 {{- define "maxscale.portName" -}}
-{{- . | lower | replace "_" "-" | trunc 15 | trimSuffix "-" -}}
+{{- $name := regexReplaceAll "[^a-z0-9-]" (lower .) "-" | trunc 15 | trimAll "-" -}}
+{{- if not $name -}}
+{{- fail (printf "maxscale: router id %q sanitizes to an empty port name — use characters in [a-z0-9]" .) -}}
+{{- end -}}
+{{- $name -}}
 {{- end -}}
 
 {{/*

--- a/kubernetes/maxscale/templates/deployment.yaml
+++ b/kubernetes/maxscale/templates/deployment.yaml
@@ -91,8 +91,23 @@ spec:
               value: {{ .Values.maxscaleConfig.monitor_user }}
             - name: MONITOR_PASSWORD
               value: {{ .Values.maxscaleConfig.monitor_user_password }}
+            - name: MAXSCALE_ROUTERS
+              value: "{{- range $i, $r := .Values.routers }}{{- if $i }},{{ end }}{{ $r.id }}{{- end }}"
+            {{- range .Values.routers }}
+            - name: MXS_{{ .id }}_TYPE
+              value: {{ .type | quote }}
+            - name: MXS_{{ .id }}_PORT
+              value: {{ .port | quote }}
+            {{- if .options }}
+            - name: MXS_{{ .id }}_ROUTER_OPTIONS
+              value: {{ .options | quote }}
+            {{- end }}
+            {{- end }}
           ports:
-          - containerPort: {{ .Values.maxscaleConfig.port }}
+          {{- range .Values.routers }}
+            - name: {{ .id | replace "_" "-" | trunc 15 }}
+              containerPort: {{ .port }}
+          {{- end }}
       imagePullSecrets:
       - name: ghcr-pull-secret
       affinity:
@@ -114,9 +129,12 @@ spec:
   selector:
     app.kubernetes.io/component: maxscale
   ports:
-    - protocol: TCP
-      port: 3306
-      targetPort: {{ .Values.maxscaleConfig.port }}
+    {{- range .Values.routers }}
+    - name: {{ .id | replace "_" "-" | trunc 15 }}
+      protocol: TCP
+      port: {{ .servicePort }}
+      targetPort: {{ .port }}
+    {{- end }}
   {{- if .Values.global.externalIP }}
   externalIPs:
   - {{ .Values.global.externalIP }}

--- a/kubernetes/maxscale/templates/deployment.yaml
+++ b/kubernetes/maxscale/templates/deployment.yaml
@@ -105,7 +105,7 @@ spec:
             {{- end }}
           ports:
           {{- range .Values.routers }}
-            - name: {{ .id | replace "_" "-" | trunc 15 }}
+            - name: {{ .id | lower | replace "_" "-" | trunc 15 | trimSuffix "-" }}
               containerPort: {{ .port }}
           {{- end }}
       imagePullSecrets:
@@ -130,7 +130,7 @@ spec:
     app.kubernetes.io/component: maxscale
   ports:
     {{- range .Values.routers }}
-    - name: {{ .id | replace "_" "-" | trunc 15 }}
+    - name: {{ .id | lower | replace "_" "-" | trunc 15 | trimSuffix "-" }}
       protocol: TCP
       port: {{ .servicePort }}
       targetPort: {{ .port }}

--- a/kubernetes/maxscale/templates/deployment.yaml
+++ b/kubernetes/maxscale/templates/deployment.yaml
@@ -91,8 +91,10 @@ spec:
               value: {{ .Values.maxscaleConfig.monitor_user }}
             - name: MONITOR_PASSWORD
               value: {{ .Values.maxscaleConfig.monitor_user_password }}
+            {{- include "maxscale.assertUniqueRouters" . }}
             - name: MAXSCALE_ROUTERS
               value: "{{- range $i, $r := .Values.routers }}{{- if $i }},{{ end }}{{ $r.id }}{{- end }}"
+            {{- $reserved := list "type" "port" "servers" }}
             {{- range .Values.routers }}
             - name: MXS_{{ .id }}_TYPE
               value: {{ .type | quote }}
@@ -108,13 +110,16 @@ spec:
             {{- end }}
             {{- $rid := .id }}
             {{- range $k, $v := .params }}
+            {{- if has (lower $k) $reserved }}
+            {{- fail (printf "maxscale: router %q uses reserved key %q in params — use the top-level .%s field instead" $rid $k (lower $k)) }}
+            {{- end }}
             - name: MXS_{{ $rid }}_{{ $k | upper }}
               value: {{ $v | quote }}
             {{- end }}
             {{- end }}
           ports:
           {{- range .Values.routers }}
-            - name: {{ .id | lower | replace "_" "-" | trunc 15 | trimSuffix "-" }}
+            - name: {{ include "maxscale.portName" .id }}
               containerPort: {{ .port }}
           {{- end }}
       imagePullSecrets:

--- a/kubernetes/maxscale/templates/deployment.yaml
+++ b/kubernetes/maxscale/templates/deployment.yaml
@@ -102,6 +102,15 @@ spec:
             - name: MXS_{{ .id }}_ROUTER_OPTIONS
               value: {{ .options | quote }}
             {{- end }}
+            {{- if .servers }}
+            - name: MXS_{{ .id }}_SERVERS
+              value: {{ join "," .servers | quote }}
+            {{- end }}
+            {{- $rid := .id }}
+            {{- range $k, $v := .params }}
+            - name: MXS_{{ $rid }}_{{ $k | upper }}
+              value: {{ $v | quote }}
+            {{- end }}
             {{- end }}
           ports:
           {{- range .Values.routers }}

--- a/kubernetes/maxscale/templates/deployment.yaml
+++ b/kubernetes/maxscale/templates/deployment.yaml
@@ -129,23 +129,3 @@ spec:
                   values:
                     - maxscale
             topologyKey: kubernetes.io/hostname
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: mariadb
-spec:
-  selector:
-    app.kubernetes.io/component: maxscale
-  ports:
-    {{- range .Values.routers }}
-    - name: {{ .id | lower | replace "_" "-" | trunc 15 | trimSuffix "-" }}
-      protocol: TCP
-      port: {{ .servicePort }}
-      targetPort: {{ .port }}
-    {{- end }}
-  {{- if .Values.global.externalIP }}
-  externalIPs:
-  - {{ .Values.global.externalIP }}
-  {{- end }}
-  type: ClusterIP

--- a/kubernetes/maxscale/templates/service.yaml
+++ b/kubernetes/maxscale/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb
+spec:
+  selector:
+    app.kubernetes.io/component: maxscale
+  ports:
+    {{- range .Values.routers }}
+    - name: {{ .id | lower | replace "_" "-" | trunc 15 | trimSuffix "-" }}
+      protocol: TCP
+      port: {{ .servicePort }}
+      targetPort: {{ .port }}
+    {{- end }}
+  {{- if .Values.global.externalIP }}
+  externalIPs:
+  - {{ .Values.global.externalIP }}
+  {{- end }}
+  type: ClusterIP

--- a/kubernetes/maxscale/templates/service.yaml
+++ b/kubernetes/maxscale/templates/service.yaml
@@ -6,8 +6,9 @@ spec:
   selector:
     app.kubernetes.io/component: maxscale
   ports:
+    {{- include "maxscale.assertUniqueRouters" . }}
     {{- range .Values.routers }}
-    - name: {{ .id | lower | replace "_" "-" | trunc 15 | trimSuffix "-" }}
+    - name: {{ include "maxscale.portName" .id }}
       protocol: TCP
       port: {{ .servicePort }}
       targetPort: {{ .port }}

--- a/kubernetes/maxscale/values.yaml
+++ b/kubernetes/maxscale/values.yaml
@@ -26,6 +26,14 @@ maxscaleConfig:
     - db03://10.98.3.13:3306
   monitor_user: maxscale_monitor
   monitor_user_password: maxscale@123
-  port: 4006
+
+# List of MaxScale router services to expose. Each entry becomes a router
+# inside the container (env MXS_<id>_TYPE / _PORT / _ROUTER_OPTIONS) and a
+# port on the mariadb Service. Default = single readwritesplit on 4006.
+routers:
+  - id: rwsplit
+    type: readwritesplit
+    port: 4006
+    servicePort: 3306
 
 replicaCount: 2

--- a/kubernetes/maxscale/values.yaml
+++ b/kubernetes/maxscale/values.yaml
@@ -29,11 +29,77 @@ maxscaleConfig:
 
 # List of MaxScale router services to expose. Each entry becomes a router
 # inside the container (env MXS_<id>_TYPE / _PORT / _ROUTER_OPTIONS) and a
-# port on the mariadb Service. Default = single readwritesplit on 4006.
+# port on the mariadb Service. Default = single readwritesplit on 4006,
+# unscoped (no `servers` = all backends from maxscaleConfig.server), no
+# extra tuning `params` (MaxScale defaults apply).
+#
+# Optional per-router fields (image >= v1.0.10 required):
+#   servers: [id1, id2, ...]   # scope this router to a backend subset.
+#                              # Omit = all backends. Renders MXS_<id>_SERVERS.
+#   params:                    # free-form map of MaxScale router tuning
+#     key: value               # params. Renders MXS_<id>_<KEY> (upper-cased)
+#                              # for each entry, e.g. causal_reads: universal
+#                              # -> MXS_<id>_CAUSAL_READS=universal.
+#   options: "a=b,c=d"         # legacy free-text router_options string.
+#                              # Still supported; params.router_options is
+#                              # the equivalent, preferred going forward.
 routers:
   - id: rwsplit
     type: readwritesplit
     port: 4006
     servicePort: 3306
+
+# --- Copy-paste recipes (all commented out; enable by uncommenting and
+# --- replacing the default `routers:` list above) ---
+
+# Recipe 1: rwsplit with causal_reads=universal
+# Use when the app needs read-your-writes consistency on Galera — after a
+# write, an immediate read on any node reflects that write, at the cost of
+# a small extra wait on reads.
+# routers:
+#   - id: rwsplit
+#     type: readwritesplit
+#     port: 4006
+#     servicePort: 3306
+#     params:
+#       causal_reads: universal
+
+# Recipe 2: readconnroute pinned to master
+# Use when you want a single write endpoint that always resolves to the
+# current primary/master, following failover automatically (rather than
+# doing read/write splitting).
+# routers:
+#   - id: write
+#     type: readconnroute
+#     port: 4007
+#     servicePort: 3307
+#     params:
+#       router_options: master
+
+# Recipe 3: multi-router mix — rwsplit + readconnroute on the same Galera
+# subset, plus a schemarouter spanning two topologies.
+# Use when OLTP traffic needs read/write splitting (rwsplit), read-heavy
+# reporting traffic should be offloaded to replicas (readconnroute with
+# router_options: slave), and a separate schemarouter needs to route by
+# schema across both a Galera cluster (g1) and a standalone/master-replica
+# topology (m1).
+# routers:
+#   - id: rwsplit
+#     type: readwritesplit
+#     port: 4006
+#     servicePort: 3306
+#     servers: [g1, g2, g3]
+#   - id: readoffload
+#     type: readconnroute
+#     port: 4008
+#     servicePort: 3308
+#     servers: [g1, g2, g3]
+#     params:
+#       router_options: slave
+#   - id: schema
+#     type: schemarouter
+#     port: 4009
+#     servicePort: 3309
+#     servers: [g1, m1]
 
 replicaCount: 2


### PR DESCRIPTION
## Summary

- Adds two new optional fields to `routers[*]` in the maxscale chart values:
  - `servers` (list of backend names) → renders `MXS_<id>_SERVERS` env var, scoping the router to a backend subset.
  - `params` (free-form map) → renders `MXS_<id>_<KEY>` env vars for per-router tuning (e.g. `causal_reads`, `router_options`).
- Ships a new operator-facing `README.md` with values reference, router-type guide, and three copy-paste recipes. Same recipes live as commented-out blocks in `values.yaml`.
- Extracts the mariadb `Service` out of `deployment.yaml` into its own `templates/service.yaml`.
- Bumps `image.tag` to `v1.0.10` (the released image that supports the new env-var contract; older tags ignore new env vars and keep working via the legacy path).

Supersedes #128 (which shipped the multi-router support this PR builds on).

## Test plan

- [x] `helm lint kubernetes/maxscale/` clean.
- [x] `helm template` dry-run with `servers` + `params` overrides → confirms `MXS_<id>_SERVERS` and upper-cased `MXS_<id>_<PARAM>` env vars render.
- [x] `helm template` with default values → no new env vars, backward compatible.
- [x] Lab install in `maxscale-test` ns against 3 Galera backends → auto-monitor `galera_rwsplit` created, both routers show the 3-server subset via REST API, `causal_reads=universal` and `router_options=slave` confirmed on the respective services.