### PR TITLE
fix: enable Flux HTTP endpoint on influxdb

### DIFF
--- a/kubernetes/influxdb/values.yaml
+++ b/kubernetes/influxdb/values.yaml
@@ -212,7 +212,9 @@ influxdb:
   ##  - name: INFLUXDB_DATA_QUERY_LOG_ENABLED
   ##    value: "true"
   ##
-  # extraEnvVars:
+  extraEnvVars:
+    - name: INFLUXDB_HTTP_FLUX_ENABLED
+      value: "true"
 
   ## Number of InfluxDB(TM) replicas to deploy
   ##


### PR DESCRIPTION
## Summary
- Set `INFLUXDB_HTTP_FLUX_ENABLED=true` on the influxdb chart via the existing `extraEnvVars` escape hatch so the InfluxDB 1.x `/api/v2/query` Flux endpoint is exposed.
- Values-only change; no template edits.

## Test plan
- [x] `helm lint kubernetes/influxdb` passes.
- [x] `helm template` renders `INFLUXDB_HTTP_FLUX_ENABLED=true` in the StatefulSet's container env list.
- [x] Deploy to a lab k8s namespace and confirm `curl -G http://<pod>:8086/api/v2/query` no longer returns "Flux query service disabled".