### PR TITLE
no-ci: Implement pre-merge-commit hook for betterleaks

### DIFF
--- a/.githooks/pre-merge-commit
+++ b/.githooks/pre-merge-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+export INSTALL_DIR="/tmp"
+
+echo "[HOOK] Running betterleaks (merge)..."
+
+# Ensure installed
+./.githooks/install-betterleaks.sh
+
+# Run scan on the merge result staged in the index
+if $INSTALL_DIR/betterleaks git --staged --verbose; then
+  git config --local betterleaks-status.var "passed"
+  echo "betterleaks passed"
+else
+  git config --local betterleaks-status.var "failed"
+  echo "Secret detected. Please review the output above and remove any secrets before completing the merge."
+  exit 1 # Comment this line if use detect mode
+fi


### PR DESCRIPTION
Adds `.githooks/pre-merge-commit` from `svtechnmaa/.github` so merge commits run betterleaks against the staged merge result.

Validation:
- Signed commit pushed to `fix/githook`.